### PR TITLE
refactor spec parameters

### DIFF
--- a/spec/defines/vim_dotvim_spec.rb
+++ b/spec/defines/vim_dotvim_spec.rb
@@ -8,35 +8,50 @@ describe 'vim::dotvim', :type => :define do
 
     let(:title) { $user_home }
 
-    let(:params) {
+    let(:valid_required_params) do
       { 
-        'user' => $user,
+        :user => $user,
       }
-    }
-
-    it { is_expected.to contain_vcsrepo($dotvim_path).with(
-        'ensure'   => 'present',
-        'provider' => 'git',
-        'source'   => 'https://github.com/teleivo/dotvim.git',
-        'user'     => $user,
-      )
-    }
-
-    it { is_expected.to contain_file($user_home + "/.vimrc").with(
-        'ensure' => 'link',
-        'owner'  => $user,
-        'target' => $dotvim_path + "/vimrc",
-      )
-    }
-
-    it 'should not compile when user is not a string' do
-      params.merge!({'user' => true})
-      should_not compile
     end
 
-    it 'should not compile when user_home is not an absolute path' do
-      params.merge!({'user_home' => 'home/teleivo'})
-      should_not compile
+    context 'with only required parameters given' do
+      let :params do
+        valid_required_params
+      end
+      it { is_expected.to contain_vcsrepo($dotvim_path).with(
+          'ensure'   => 'present',
+          'provider' => 'git',
+          'source'   => 'https://github.com/teleivo/dotvim.git',
+          'user'     => $user,
+        )
+      }
+
+      it { is_expected.to contain_file($user_home + "/.vimrc").with(
+          'ensure' => 'link',
+          'owner'  => $user,
+          'target' => $dotvim_path + "/vimrc",
+        )
+      }
+    end
+
+    context 'with invalid parameters' do
+      describe 'when user is not a string' do
+        let :params do
+          valid_required_params.merge({
+            :user => true,
+          })
+        end
+        it { should_not compile }
+      end
+
+      describe 'when user_home is not an absolute path' do
+        let :params do
+          valid_required_params.merge({
+            :user_home => 'home/teleivo',
+          })
+        end
+        it { should_not compile }
+      end
     end
   end
 end


### PR DESCRIPTION
- arrange tests into different contexts for readability
- defined valid required parameters on top
- merge them in every context with additional parameters
  when necessary
