### PR TITLE
create symbolic link only when repo was cloned

### DIFF
--- a/manifests/dotvim.pp
+++ b/manifests/dotvim.pp
@@ -15,8 +15,9 @@ define vim::dotvim (
   }
 
   file { "${user_home}/.vimrc":
-    ensure => link,
-    owner  => $user,
-    target => "${dotvim_path}/vimrc",
+    ensure  => link,
+    owner   => $user,
+    target  => "${dotvim_path}/vimrc",
+    require => Vcsrepo[$dotvim_path],
   }
 }

--- a/spec/defines/vim_dotvim_spec.rb
+++ b/spec/defines/vim_dotvim_spec.rb
@@ -27,9 +27,10 @@ describe 'vim::dotvim', :type => :define do
       }
 
       it { is_expected.to contain_file($user_home + "/.vimrc").with(
-          'ensure' => 'link',
-          'owner'  => $user,
-          'target' => $dotvim_path + "/vimrc",
+          'ensure'  => 'link',
+          'owner'   => $user,
+          'target'  => $dotvim_path + "/vimrc",
+          'require' => "Vcsrepo[" + $dotvim_path + "]",
         )
       }
     end


### PR DESCRIPTION
- add dependency from .vimrc link to vcsrepo
  so that no dead link is created if git clone fails
